### PR TITLE
fix: market-installed persistence utils has library errors

### DIFF
--- a/persistence-utils-demo-test/pom.xml
+++ b/persistence-utils-demo-test/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.axonivy.utils.persistence</groupId>
 	<artifactId>persistence-utils-demo-test</artifactId>
 	<version>10.0.1-SNAPSHOT</version>
-	<packaging>iar-integration-test</packaging>
+	<packaging>iar</packaging>
 	<description>Test project of the persistence utils demo project. Note, that this project is currently also used to test some aspects of the persistence library.</description>
 	<dependencies>
 		<dependency>

--- a/persistence-utils-demo/pom.xml
+++ b/persistence-utils-demo/pom.xml
@@ -20,6 +20,17 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+  
+  <repositories>
+    <repository>
+      <id>axonivy.public</id>
+      <url>https://maven.axonivy.com</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+  
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
market-installed product, after unpacking it, the persistence-utils:jar is stated as missing 
... as lib/mvn-deps is no longer in charge
... but there is no repository to resolve the built jar