### PR TITLE
APS-231 GitHub 73: fixed handling of desc order in search filters

### DIFF
--- a/persistence-utils-demo-test/src_test/com/axonivy/utils/persistence/test/dao/SearchFilterTest.java
+++ b/persistence-utils-demo-test/src_test/com/axonivy/utils/persistence/test/dao/SearchFilterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -193,6 +194,24 @@ public class SearchFilterTest extends DemoTestBase {
 		return tuples.stream().map(t -> (MaritalStatus)t.get(0)).distinct().sorted().toList();
 	}
 
+	@Test
+	public void testSortingAsc() {
+		var ascIvyUserFilter = SearchFilter.create()
+		.add(PersonSearchField.IVY_USER_NAME)
+		.addSort(PersonSearchField.IVY_USER_NAME, true);
+		var asc = PersonDAO.getInstance().findBySearchFilter(ascIvyUserFilter);
+		assertThat(asc.stream().map(t -> t.get(0, String.class))).isSorted();
+	}
+	
+	@Test
+	public void testSortingDesc() {
+		var descIvyUserFilter = SearchFilter.create()
+		.add(PersonSearchField.IVY_USER_NAME)
+		.addSort(PersonSearchField.IVY_USER_NAME, false);
+		var desc = PersonDAO.getInstance().findBySearchFilter(descIvyUserFilter);
+		assertThat(desc.stream().map(t -> t.get(0, String.class))).isSortedAccordingTo(Comparator.reverseOrder());
+	}
+	
 	@Test
 	public void testEnumList() {
 		var filter = SearchFilter.create()

--- a/persistence-utils-product/README.md
+++ b/persistence-utils-product/README.md
@@ -14,6 +14,11 @@ Axon Ivy's JPA Persistence Lib utility helps you accelerate process automation i
 
 ## Release Notes
 
+### 11.3.2-SNAPSHOT
+*Changes*
+
+- [APS-232](https://1ivy.atlassian.net/browse/APS-232) Fix GitHub issue 73 (SearchFilter descending sort)
+
 ### 10.0.8
 *Changes*
 

--- a/persistence-utils-product/README_DE.md
+++ b/persistence-utils-product/README_DE.md
@@ -16,6 +16,11 @@ Axon Ivy's JPA Persistence Lib unterstützt dich dabei, Prozessautomatisierungsi
 
 ## Release Notes
 
+### 11.3.2-SNAPSHOT
+*Änderungen*
+
+- [APS-231](https://1ivy.atlassian.net/browse/APS-231) Fix GitHub issue 73 (SearchFilter descending sort)
+
 ### 10.0.8
 *Änderungen*
 - [APS-224](https://1ivy.atlassian.net/browse/APS-224) Behebung des Handlings von leeren Listen oder Null-Werten in Enum-Suchfiltern.

--- a/persistence-utils/src/com/axonivy/utils/persistence/dao/GenericDAO.java
+++ b/persistence-utils/src/com/axonivy/utils/persistence/dao/GenericDAO.java
@@ -1497,7 +1497,7 @@ public abstract class GenericDAO<M extends GenericEntity_, T extends GenericEnti
 		}
 
 		// Add all needed orders.
-		for (FilterOrder filterOrder : searchFilter.getFilterOrders()) {
+		for (var filterOrder : searchFilter.getFilterOrders()) {
 			var orders = orderMap.get(filterOrder.getSearchEnum());
 
 			if(orders == null) {
@@ -1518,7 +1518,7 @@ public abstract class GenericDAO<M extends GenericEntity_, T extends GenericEnti
 					// whether multi-select filters will even be used, will be seen.
 					// At the moment all filters produce a single selection, so this all
 					// does not really matter.
-					orders.stream().forEach(o -> o.reverse());
+					orders = orders.stream().map(Order::reverse).toList();
 				}
 				// Add all orders.
 				attributePredicates.addOrders(orders);


### PR DESCRIPTION
Fix is needed to make desc sorting work in Ivy 12.