### PR TITLE
MARP-2088 Fix issue 82 Error classcastexception when re using an object expression with getexpression

### DIFF
--- a/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/ChildTestEntity.java
+++ b/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/ChildTestEntity.java
@@ -1,0 +1,34 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import com.axonivy.utils.persistence.beans.GenericIdEntity;
+
+@Entity
+public class ChildTestEntity extends GenericIdEntity {
+	private static final long serialVersionUID = 1L;
+
+	@Column
+	private String name;
+	
+	@ManyToOne()
+	private ParentTestEntity parent;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public ParentTestEntity getParent() {
+		return parent;
+	}
+
+	public void setParent(ParentTestEntity parent) {
+		this.parent = parent;
+	}
+}

--- a/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/GrandParentTestEntity.java
+++ b/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/GrandParentTestEntity.java
@@ -1,0 +1,14 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+
+import com.axonivy.utils.persistence.beans.GenericIdEntity;
+
+@Entity
+public class GrandParentTestEntity extends GenericIdEntity {
+	private static final long serialVersionUID = 1L;
+
+	@Column
+	private String name;
+}

--- a/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/ParentTestEntity.java
+++ b/persistence-utils-demo-test/src/com/axonivy/utils/persistence/entities/family/ParentTestEntity.java
@@ -1,0 +1,34 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import com.axonivy.utils.persistence.beans.GenericIdEntity;
+
+@Entity
+public class ParentTestEntity extends GenericIdEntity {
+	private static final long serialVersionUID = 1L;
+
+	@Column
+	private String name;
+
+	@ManyToOne()
+	private GrandParentTestEntity grandParent;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public GrandParentTestEntity getGrandParent() {
+		return grandParent;
+	}
+
+	public void setGrandParent(GrandParentTestEntity grandParent) {
+		this.grandParent = grandParent;
+	}
+}

--- a/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/ChildTestEntity_.java
+++ b/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/ChildTestEntity_.java
@@ -1,0 +1,18 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.annotation.Generated;
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@Generated(value = "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor")
+@StaticMetamodel(ChildTestEntity.class)
+public abstract class ChildTestEntity_ extends com.axonivy.utils.persistence.beans.GenericIdEntity_ {
+
+	public static volatile SingularAttribute<ChildTestEntity, ParentTestEntity> parent;
+	public static volatile SingularAttribute<ChildTestEntity, String> name;
+
+	public static final String PARENT = "parent";
+	public static final String NAME = "name";
+
+}
+

--- a/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/GrandParentTestEntity_.java
+++ b/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/GrandParentTestEntity_.java
@@ -1,0 +1,16 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.annotation.Generated;
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@Generated(value = "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor")
+@StaticMetamodel(GrandParentTestEntity.class)
+public abstract class GrandParentTestEntity_ extends com.axonivy.utils.persistence.beans.GenericIdEntity_ {
+
+	public static volatile SingularAttribute<GrandParentTestEntity, String> name;
+
+	public static final String NAME = "name";
+
+}
+

--- a/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/ParentTestEntity_.java
+++ b/persistence-utils-demo-test/src_generated/com/axonivy/utils/persistence/entities/family/ParentTestEntity_.java
@@ -1,0 +1,18 @@
+package com.axonivy.utils.persistence.entities.family;
+
+import javax.annotation.Generated;
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@Generated(value = "org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor")
+@StaticMetamodel(ParentTestEntity.class)
+public abstract class ParentTestEntity_ extends com.axonivy.utils.persistence.beans.GenericIdEntity_ {
+
+	public static volatile SingularAttribute<ParentTestEntity, GrandParentTestEntity> grandParent;
+	public static volatile SingularAttribute<ParentTestEntity, String> name;
+
+	public static final String GRAND_PARENT = "grandParent";
+	public static final String NAME = "name";
+
+}
+

--- a/persistence-utils-demo-test/src_test/com/axonivy/utils/persistence/test/dao/ExpressionTest.java
+++ b/persistence-utils-demo-test/src_test/com/axonivy/utils/persistence/test/dao/ExpressionTest.java
@@ -1,0 +1,40 @@
+package com.axonivy.utils.persistence.test.dao;
+
+import org.junit.jupiter.api.Test;
+
+import com.axonivy.utils.persistence.dao.ExpressionMap;
+import com.axonivy.utils.persistence.dao.GenericIdEntityDAO;
+import com.axonivy.utils.persistence.daos.BaseDAO;
+import com.axonivy.utils.persistence.entities.family.ChildTestEntity;
+import com.axonivy.utils.persistence.entities.family.ChildTestEntity_;
+import com.axonivy.utils.persistence.entities.family.GrandParentTestEntity_;
+import com.axonivy.utils.persistence.entities.family.ParentTestEntity_;
+
+import ch.ivyteam.ivy.environment.IvyTest;
+
+@IvyTest
+public class ExpressionTest {
+	private ChildTestEntityDAO dao = new ChildTestEntityDAO();
+
+	@Test
+	public void testIssue82() {
+		dao.testIssue82();
+	}
+
+	protected class ChildTestEntityDAO extends GenericIdEntityDAO<ChildTestEntity_, ChildTestEntity> implements BaseDAO {
+
+		@Override
+		protected Class<ChildTestEntity> getType() {
+			return ChildTestEntity.class;
+		}
+
+		public void testIssue82() {
+			try (var ctx = initializeQuery()) {
+				var map = ExpressionMap.createNewExpressionMap();
+				getExpressionGeneral(map, ctx.r, ChildTestEntity_.parent);
+				getExpressionGeneral(map, ctx.r, ChildTestEntity_.parent, ParentTestEntity_.grandParent, GrandParentTestEntity_.name);
+			}
+		}
+	}
+}
+

--- a/persistence-utils/src/com/axonivy/utils/persistence/dao/AbstractDAO.java
+++ b/persistence-utils/src/com/axonivy/utils/persistence/dao/AbstractDAO.java
@@ -26,13 +26,14 @@ import javax.persistence.Version;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.From;
 import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.Attribute;
-import javax.persistence.metamodel.Attribute.PersistentAttributeType;
+import javax.persistence.metamodel.CollectionAttribute;
 import javax.persistence.metamodel.ListAttribute;
+import javax.persistence.metamodel.MapAttribute;
 import javax.persistence.metamodel.PluralAttribute;
+import javax.persistence.metamodel.SetAttribute;
 import javax.persistence.metamodel.SingularAttribute;
 import javax.transaction.TransactionRolledbackException;
 
@@ -1475,72 +1476,39 @@ public abstract class AbstractDAO implements BaseDAO {
 	 * @param from
 	 * @param attributes
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private static Expression<?> getExpressionInternal(ExpressionMap expressionMap, boolean create, From<?, ?> from,
-			Attribute<?, ?>... attributes) {
-		Path<?> tmpPath = from;
-		String key = tmpPath.getJavaType().getCanonicalName();
-		Expression result = tmpPath;
+	@SuppressWarnings("rawtypes")
+	private static Expression<?> getExpressionInternal(ExpressionMap expressionMap, boolean create, From<?, ?> from, Attribute<?, ?>... attributes) {
+		Path path = from;
+		var key = path.getJavaType().getCanonicalName();
 
-		for (int i = 0; i < attributes.length; i++) {
-			boolean last = i == attributes.length - 1;
-			Attribute<?, ?> attribute = attributes[i];
+		for (var i = 0; i < attributes.length; i++) {
+			var attribute = attributes[i];
 
 			key += "." + attribute.getName();
 
-			LOG.debug("expression key: {0}", key);
+			LOG.debug("Working on expression with key: {0}", key);
 
-			if (!last) {
-				Path cachedPath = null;
+			Path cachedPath = expressionMap != null ? (Path)expressionMap.get(key) : null;
 
-				if (expressionMap != null) {
-					cachedPath = (Path) expressionMap.get(key);
-				}
-				if (cachedPath == null) {
-					if (create) {
-						LOG.debug("creating new expression");
-						tmpPath = getNextAttribute(tmpPath, attribute);
+			if (cachedPath == null) {
+				if (create) {
+					LOG.debug("Creating new expression for key: {0}", key);
+					path = getNextAttribute(path, attribute);
 
-						if (expressionMap != null) {
-							// cache for future calls
-							expressionMap.put(key, tmpPath);
-						}
-					} else {
-						tmpPath = null;
+					if (expressionMap != null) {
+						// Cache for future calls.
+						expressionMap.put(key, path);
 					}
 				} else {
-					tmpPath = cachedPath;
-					LOG.debug("re-using join");
+					path = null;
 				}
 			} else {
-				Expression cachedExpression = null;
-				if (expressionMap != null) {
-					cachedExpression = expressionMap.get(key);
-				}
-				if (cachedExpression == null) {
-					if (create) {
-						LOG.debug("creating new expression");
-						if (attribute instanceof SingularAttribute) {
-							result = tmpPath.get((SingularAttribute) attribute);
-						} else if (attribute instanceof ListAttribute) {
-							result = tmpPath.get((ListAttribute) attribute);
-						}
-
-						if (expressionMap != null) {
-							// cache for future calls
-							expressionMap.put(key, result);
-						}
-					} else {
-						result = null;
-					}
-				} else {
-					result = cachedExpression;
-					LOG.debug("re-using expression");
-				}
+				LOG.debug("Re-using path for key: {0}", key);
+				path = cachedPath;
 			}
 		}
 
-		return result;
+		return path;
 	}
 
 	/**
@@ -1550,28 +1518,32 @@ public abstract class AbstractDAO implements BaseDAO {
 	 * @param attribute
 	 * @return
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private static Path<?> getNextAttribute(Path<?> path, Attribute<?, ?> attribute) {
-		Path<?> resultPath = path;
-		PersistentAttributeType aType = attribute.getPersistentAttributeType();
-		if (attribute instanceof SingularAttribute) {
-			if (aType == PersistentAttributeType.EMBEDDED) {
-				resultPath = path.get((SingularAttribute) attribute);
-			} else {
-				if (!(path instanceof From)) {
-					LOG.error("When building the JPA expression for a singular attribute " + attribute
-							+ " , a Path was needed but instead " + path + " was found, query build will fail");
-				}
-				resultPath = ((From) path).join((SingularAttribute) attribute, JoinType.LEFT);
+		var resultPath = path;
+
+		if(path instanceof From from && attribute.isAssociation()) {
+			if(attribute instanceof SingularAttribute single) {
+				resultPath = from.join(single);
 			}
-		} else if (attribute instanceof ListAttribute) {
-			if (!(path instanceof From)) {
-				LOG.error("When building the JPA expression for a list attribute " + attribute
-						+ " , a Path was needed but instead " + path + " was found, query build will fail");
+			else if(attribute instanceof ListAttribute list) {
+				resultPath = from.join(list);
 			}
-			resultPath = ((From) path).join((ListAttribute) attribute, JoinType.LEFT);
-		} else {
-			LOG.error("When building the JPA expression unhandled attribute " + attribute + " was found.");
+			else if(attribute instanceof SetAttribute set) {
+				resultPath = from.join(set);
+			}
+			else if(attribute instanceof MapAttribute map) {
+				resultPath = from.join(map);
+			}
+			else if(attribute instanceof CollectionAttribute collection) {
+				resultPath = from.join(collection);
+			}
+			else {
+				LOG.error("Attribute type {0} is currently not supported.", path != null ? path.getClass() : null);
+			}
+		}
+		else {
+			resultPath = path.get((SingularAttribute) attribute);
 		}
 		return resultPath;
 	}


### PR DESCRIPTION
The last element of getExpressionInternal is now be cached as a Join instead of a Path if it is an association.